### PR TITLE
Allow Colors in Language.yml (#10)

### DIFF
--- a/src/realisticSwimming/commands/ToggleFall.java
+++ b/src/realisticSwimming/commands/ToggleFall.java
@@ -16,6 +16,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
+
+import net.md_5.bungee.api.ChatColor;
 import realisticSwimming.Language;
 import realisticSwimming.events.PlayerDisableFallingEvent;
 import realisticSwimming.events.PlayerEnableFallingEvent;
@@ -36,7 +38,9 @@ public class ToggleFall extends RSCommand {
 			Player p = (Player) sender;
 			if(arg3[0].equalsIgnoreCase("on")){
 				p.removeMetadata("fallingDisabled", plugin);
-				sendMessage(p, Language.fallingEnabled);
+				//****************************** Changes by DrkMatr1984 START ******************************
+				sendMessage(p, ChatColor.translateAlternateColorCodes('&', Language.fallingEnabled));
+				//****************************** Changes by DrkMatr1984 END ******************************
 
 				//Fire PlayerEnableFallingEvent
 				PlayerEnableFallingEvent event = new PlayerEnableFallingEvent(p);
@@ -46,8 +50,10 @@ public class ToggleFall extends RSCommand {
 
 			}else if(arg3[0].equalsIgnoreCase("off")){
 				p.setMetadata("fallingDisabled", meta);
-				sendMessage(p, Language.fallingDisabled);
-
+				//****************************** Changes by DrkMatr1984 START ******************************
+				sendMessage(p, ChatColor.translateAlternateColorCodes('&', Language.fallingDisabled));
+				//****************************** Changes by DrkMatr1984 END ******************************
+				
 				//Fire PlayerDisableFallingEvent
 				PlayerDisableFallingEvent event = new PlayerDisableFallingEvent(p);
 				Bukkit.getServer().getPluginManager().callEvent(event);

--- a/src/realisticSwimming/commands/ToggleSwim.java
+++ b/src/realisticSwimming/commands/ToggleSwim.java
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 package realisticSwimming.commands;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -36,7 +37,9 @@ public class ToggleSwim extends RSCommand {
 			Player p = (Player) sender;
 			if(arg3[0].equalsIgnoreCase("on")){
 				p.removeMetadata("swimmingDisabled", plugin);
-				sendMessage(p, Language.swimmingEnabled);
+				//****************************** Changes by DrkMatr1984 START ******************************
+				sendMessage(p, ChatColor.translateAlternateColorCodes('&', Language.swimmingEnabled));
+				//****************************** Changes by DrkMatr1984 END ******************************
 
 				//Fire PlayerEnableSwimmingEvent
 				PlayerEnableSwimmingEvent event = new PlayerEnableSwimmingEvent(p);
@@ -46,7 +49,9 @@ public class ToggleSwim extends RSCommand {
 
 			}else if(arg3[0].equalsIgnoreCase("off")){
 				p.setMetadata("swimmingDisabled", meta);
-				sendMessage(p, Language.swimmingDisabled);
+				//****************************** Changes by DrkMatr1984 START ******************************
+				sendMessage(p, ChatColor.translateAlternateColorCodes('&', Language.swimmingDisabled));
+				//****************************** Changes by DrkMatr1984 END ******************************
 
 				//Fire PlayerDisableSwimmingEvent
 				PlayerDisableSwimmingEvent event = new PlayerDisableSwimmingEvent(p);

--- a/src/realisticSwimming/main/RFallListener.java
+++ b/src/realisticSwimming/main/RFallListener.java
@@ -29,14 +29,7 @@ public class RFallListener implements Listener{
 		Player p = event.getPlayer();
 		//p.sendMessage(""+p.getFallDistance());
 		//p.sendMessage(""+p.getVelocity().getY());
-		if(playerCanFall(p)){
-			
-			//****************************** Changes by DrkMatr1984 START ******************************
-			if(isElytraDeploying(p)){
-				return;
-			}
-			//****************************** Changes by DrkMatr1984 END ******************************
-			
+		if(playerCanFall(p)){			
 			//fix NCP false alarm
 			Utility.ncpFix(p);
 
@@ -66,6 +59,11 @@ public class RFallListener implements Listener{
 	
 	public boolean playerCanFall(Player p){
 		if(!p.hasMetadata("fallingDisabled")&& Utility.playerHasPermission(p, "rs.user.fall") && p.getFallDistance()>Config.minFallDistance && Config.enableFall && p.getLocation().getBlock().getType()!=Material.STATIONARY_WATER){
+			//****************************** Changes by DrkMatr1984 START ******************************
+			if(isElytraDeploying(p)){
+				return false;
+			}
+			//****************************** Changes by DrkMatr1984 END ******************************
 			return true;
 		}
 		return false;

--- a/src/realisticSwimming/main/RSwimListener.java
+++ b/src/realisticSwimming/main/RSwimListener.java
@@ -23,7 +23,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scheduler.BukkitRunnable;
 import realisticSwimming.Config;
 import realisticSwimming.Utility;
 import realisticSwimming.events.PlayerStartSwimmingEvent;
@@ -147,8 +147,10 @@ public class RSwimListener implements Listener{
             //Debug
             //p.sendMessage("Starting stamina system...");
 
-            //start stamina system
-            @SuppressWarnings("UnusedAssignment") BukkitTask stamina = new Stamina(plugin, p, this).runTaskTimer(plugin, 0, Config.staminaUpdateDelay);
+            //****************************** Changes by DrkMatr1984 START ******************************
+            BukkitRunnable stamina = new Stamina(plugin, p, this);
+            stamina.runTaskTimer(plugin, 0, Config.staminaUpdateDelay);
+            //****************************** Changes by DrkMatr1984 END ******************************
         }
     }
 

--- a/src/realisticSwimming/stamina/Stamina.java
+++ b/src/realisticSwimming/stamina/Stamina.java
@@ -112,8 +112,10 @@ public class Stamina extends BukkitRunnable {
 		if(weightManager.getWeight() > Config.maxSprintingWeight && Config.enableArmorWeight){
 			//warn player when trying to sprint but to heavy
 			if(p.isSprinting() && Config.enableToHeavyToSprintWarning){
-				p.sendMessage(ChatColor.RED+Language.tooHeavyToSprint);
-				p.sendMessage(ChatColor.GOLD+Language.currentArmorWeight+" "+ChatColor.RED+weightManager.getWeight()+" "+ChatColor.GOLD+Language.maximumSprintingWeightIs+" "+ChatColor.AQUA+Config.maxSprintingWeight);
+				//****************************** Changes by DrkMatr1984 START ******************************
+				p.sendMessage(ChatColor.RED+ChatColor.translateAlternateColorCodes('&', Language.tooHeavyToSprint ));
+				p.sendMessage(ChatColor.GOLD+ChatColor.translateAlternateColorCodes('&', Language.currentArmorWeight)+" "+ChatColor.RED+weightManager.getWeight()+" "+ChatColor.GOLD+ChatColor.translateAlternateColorCodes('&', Language.maximumSprintingWeightIs)+" "+ChatColor.AQUA+Config.maxSprintingWeight);
+				//****************************** Changes by DrkMatr1984 END ******************************
 			}
 			//no sprinting when to heavy
 			p.setSprinting(false);
@@ -131,8 +133,9 @@ public class Stamina extends BukkitRunnable {
 		for(int i=0; i<10-part1.length(); i++){
 			part2 = part2+"#";
 		}
-
-		staminaBar = Language.stamina+": "+part1+ChatColor.GRAY+part2;
+		//****************************** Changes by DrkMatr1984 START ******************************
+		staminaBar = part1+ChatColor.GRAY+part2;
+		//****************************** Changes by DrkMatr1984 END ******************************
 
 		if(stamina>700){
 			staminaBar = ChatColor.GREEN+staminaBar;
@@ -143,6 +146,10 @@ public class Stamina extends BukkitRunnable {
 		}else{
 			staminaBar = ChatColor.DARK_RED+staminaBar;
 		}
+		//****************************** Changes by DrkMatr1984 START ******************************
+		staminaBar = ChatColor.translateAlternateColorCodes('&', Language.stamina)+ChatColor.RESET+": "+staminaBar;
+		//****************************** Changes by DrkMatr1984 END ******************************
+		
 		updateStaminaBar(staminaBar);
 	}
 
@@ -184,7 +191,12 @@ public class Stamina extends BukkitRunnable {
 	private void initializeScoreboard(){
 			scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
 			p.setScoreboard(scoreboard);
-			staminaObjective = scoreboard.registerNewObjective(Language.stamina, "dummy");
+			//****************************** Changes by DrkMatr1984 START ******************************
+			if(ChatColor.translateAlternateColorCodes('&', Language.stamina).length()>16)
+				staminaObjective = scoreboard.registerNewObjective(ChatColor.translateAlternateColorCodes('&', Language.stamina).substring(0, 15), "dummy");
+			else
+				staminaObjective = scoreboard.registerNewObjective(ChatColor.translateAlternateColorCodes('&', Language.stamina), "dummy");
+			//****************************** Changes by DrkMatr1984 END ******************************
 			staminaObjective.setDisplaySlot(DisplaySlot.SIDEBAR);
 	}
 	

--- a/src/realisticSwimming/stamina/StaminaBar_Native.java
+++ b/src/realisticSwimming/stamina/StaminaBar_Native.java
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 package realisticSwimming.stamina;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
@@ -23,7 +24,12 @@ public class StaminaBar_Native extends StaminaBar {
 
     StaminaBar_Native(Player player){
         super(player);
-        staminaBar = Bukkit.createBossBar(Language.stamina, BarColor.GREEN, BarStyle.SOLID);
+        //****************************** Changes by DrkMatr1984 START ******************************
+        if(ChatColor.translateAlternateColorCodes('&', Language.stamina).length()>64)
+        	staminaBar = Bukkit.createBossBar(ChatColor.translateAlternateColorCodes('&', Language.stamina).substring(0, 63), BarColor.GREEN, BarStyle.SOLID);
+        else
+        	staminaBar = Bukkit.createBossBar(ChatColor.translateAlternateColorCodes('&', Language.stamina), BarColor.GREEN, BarStyle.SOLID);
+        //****************************** Changes by DrkMatr1984 END ******************************
         staminaBar.addPlayer(p);
 
     }

--- a/src/realisticSwimming/stamina/WeightManager.java
+++ b/src/realisticSwimming/stamina/WeightManager.java
@@ -49,7 +49,11 @@ public class WeightManager {
 
     WeightManager(Player player){
         p = player;
-        weightWarning();
+        //****************************** Changes by DrkMatr1984 START ******************************
+        if(Config.enableArmorWeight){
+        	weightWarning();
+        } 
+        //****************************** Changes by DrkMatr1984 END ******************************
     }
 
     private void weightWarning(){
@@ -57,14 +61,18 @@ public class WeightManager {
         if(getWeight() > Config.maxSprintingWeight && Config.enableHeavyArmorWarningTitle){
             color = ChatColor.GOLD;
 
+            //****************************** Changes by DrkMatr1984 START ******************************
             //noinspection deprecation
-            p.sendTitle(ChatColor.RED+"/"+ChatColor.GOLD+"!"+ChatColor.RED+"\\", ChatColor.GOLD+Language.heavyArmorWarning);
+            p.sendTitle(ChatColor.RED+"/"+ChatColor.GOLD+"!"+ChatColor.RED+"\\", ChatColor.GOLD+ChatColor.translateAlternateColorCodes('&', Language.heavyArmorWarning),15,70,20);
+            //****************************** Changes by DrkMatr1984 END ******************************
         }else{
             color = ChatColor.GREEN;
         }
 
         if(Config.announceWeight){
-            p.sendMessage(ChatColor.AQUA+Language.currentArmorWeight+" "+color+getWeight());
+            //****************************** Changes by DrkMatr1984 START ******************************
+            p.sendMessage(ChatColor.AQUA+ChatColor.translateAlternateColorCodes('&', Language.currentArmorWeight)+" "+color+getWeight());
+            //****************************** Changes by DrkMatr1984 END ******************************
         }
     }
 


### PR DESCRIPTION
* Allow Colors in Language.yml

Allow colors in language.yml, fix potential bug if
Language.stamina.length() is longer than 16 characters and using
scoreboard stamina system. Fix potential bug if
Language.stamina.length() is longer than 64 characters and using BossBar
stamina system. Put Elytra plugin detection method in the right place in
RFallListener. Corrected UnusedAssignment warning in RSwimListener.java
that was causing the stamina system to sometimes not fire.